### PR TITLE
 traversal optimization for exact key lookups

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -6,17 +6,11 @@ import 'node.dart';
 abstract class RadixTreeUtils {
   /// Finds the length of the largest prefix for two character sequences.
   static int largestPrefixLength(String first, String second) {
-    var length = 0;
-
-    for (var i = 0; i < min(first.length, second.length); ++i) {
-      if (first[i] != second[i]) {
-        break;
-      }
-
-      ++length;
+    final commonLength = min(first.length, second.length);
+    for (var i = 0; i < commonLength; ++i) {
+      if (first[i] != second[i]) return i;
     }
-
-    return length;
+    return commonLength;
   }
 
   /// Put the value with the given key from the subtree rooted at the
@@ -25,12 +19,16 @@ abstract class RadixTreeUtils {
     final largestPrefix = largestPrefixLength(key, node.prefix);
 
     if (largestPrefix == node.prefix.length && largestPrefix == key.length) {
+      // Exact match, update the value here.
       node.value = value;
     } else if (largestPrefix == 0 ||
-        (largestPrefix < key.length && largestPrefix >= node.prefix.length)) {
+        (largestPrefix < key.length && largestPrefix == node.prefix.length)) {
+      // Key we're looking for shares no common prefix (e.g. at the root), OR
+      // Key we're looking for subsumes this node's string.
       final leftOverKey = key.substring(largestPrefix);
       var found = false;
 
+      // Try to find a child node that continues matching the remainder.
       for (final child in node) {
         if (child.prefix[0] == leftOverKey[0]) {
           found = true;
@@ -38,12 +36,14 @@ abstract class RadixTreeUtils {
           break;
         }
       }
-
+      // Otherwise add the remainder as a child of this node.
       if (!found) {
         final newNode = RadixTreeNode<T>(leftOverKey, value);
         node.childrend.add(newNode);
       }
-    } else if (largestPrefix < node.prefix.length) {
+    } else {
+      // case largestPrefix < node.prefix.length:
+      // Key we're looking for shares a non-empty subset of this node's string.
       final leftOverPrefix = node.prefix.substring(largestPrefix);
       final newNode = RadixTreeNode<T>(leftOverPrefix, node.value);
       newNode.childrend.addAll(node.childrend);
@@ -60,10 +60,6 @@ abstract class RadixTreeUtils {
         node.childrend.add(keyNode);
         node.value = null;
       }
-    } else {
-      final leftoverKey = key.substring(largestPrefix);
-      final newNode = RadixTreeNode<T>(leftoverKey, value);
-      node.childrend.add(newNode);
     }
   }
 

--- a/test/radix_tree_test.dart
+++ b/test/radix_tree_test.dart
@@ -77,6 +77,69 @@ void main() {
       expect(tree.getValuesWithPrefix('asd'), containsAll(const <int>[]));
     });
 
+    test('operator[] Fetch', () {
+      final tree = RadixTree<int>();
+      tree['tes'] = 0;
+      tree['test'] = 1;
+      tree['tent'] = 2;
+      tree['rest'] = 3;
+      tree['tank'] = 4;
+      tree['tan'] = 5;
+      expect(tree, hasLength(equals(6)));
+      expect(tree['tes'], equals(0));
+      expect(tree['test'], equals(1));
+      expect(tree['tent'], equals(2));
+      expect(tree['rest'], equals(3));
+      expect(tree['tank'], equals(4));
+      expect(tree['tan'], equals(5));
+      expect(tree[''], isNull);
+      expect(tree['t'], isNull);
+      expect(tree['te'], isNull);
+      expect(tree['tanke'], isNull);
+      expect(tree['asd'], isNull);
+    });
+
+    test('Contains Key', () {
+      final tree = RadixTree<int>();
+      tree['tes'] = 0;
+      tree['test'] = 1;
+      tree['tent'] = 2;
+      tree['rest'] = 3;
+      tree['tank'] = 4;
+      tree['tan'] = 5;
+      expect(tree, hasLength(equals(6)));
+      expect(() => tree.containsKey(null), throwsA(isA<NullThrownError>()));
+      expect(tree.containsKey('tes'), true);
+      expect(tree.containsKey('test'), true);
+      expect(tree.containsKey('tent'), true);
+      expect(tree.containsKey('rest'), true);
+      expect(tree.containsKey('tank'), true);
+      expect(tree.containsKey('tan'), true);
+      expect(tree.containsKey(''), false);
+      expect(tree.containsKey('t'), false);
+      expect(tree.containsKey('te'), false);
+      expect(tree.containsKey('tanke'), false);
+      expect(tree.containsKey('asd'), false);
+    });
+
+    test('Contains Value', () {
+      final tree = RadixTree<int>();
+      tree[''] = 0;
+      tree['test'] = 1;
+      tree['tent'] = 2;
+      tree['rest'] = 3;
+      tree['tank'] = 4;
+      expect(tree, hasLength(equals(5)));
+      expect(tree.containsValue(null), false);
+      expect(tree.containsValue(0), true);
+      expect(tree.containsValue(1), true);
+      expect(tree.containsValue(2), true);
+      expect(tree.containsValue(3), true);
+      expect(tree.containsValue(4), true);
+      expect(tree.containsValue(5), false);
+      expect(tree.containsValue('test'), false);
+    });
+
     test('Spook', () {
       final tree = RadixTree<int>();
       tree['pook'] = 1;
@@ -109,18 +172,18 @@ void main() {
 
       const hex = '0123456789ABCDEF';
       final random = Random();
-      final bigInts = <BigInt>[];
+      final bigInts = <BigInt>{};
       var i = 100 + random.nextInt(400);
 
       while (i > 0) {
         final bigInt = BigInt.parse(
-            List<String>.generate(20, (index) => hex[random.nextInt(0xF)])
+            List<String>.generate(20, (index) => hex[random.nextInt(0x10)])
                 .join(),
-            radix: 0xF);
+            radix: 0x10);
 
         if (!bigInts.contains(bigInt)) {
           bigInts.add(bigInt);
-          tree[bigInt.toRadixString(0xF)] = bigInt;
+          tree[bigInt.toRadixString(0x10)] = bigInt;
         }
 
         i -= 1;
@@ -129,7 +192,7 @@ void main() {
       expect(tree, hasLength(equals(bigInts.length)));
 
       for (final bigInt in bigInts) {
-        expect(tree, containsPair(bigInt.toRadixString(0xF), equals(bigInt)));
+        expect(tree, containsPair(bigInt.toRadixString(0x10), equals(bigInt)));
       }
 
       expect(tree.values, containsAll(bigInts));


### PR DESCRIPTION
- short circuit the search in operator[] and containsKey with a new
  visitKey() helper, to avoid visiting the target node's subtrees.
- add unit tests for operator[], containsKey, containsValue

Resolves #1 